### PR TITLE
Add market id to finding and merchandising apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can override the default format of an API when instantiating the request.
 ```ruby
 require 'json'
 
-# the Finding API returns XML by default
+### the Finding API returns XML by default
 request = Ebay.finding(response_data_format: 'JSON')
 response = request.find_items_by_keywords('iphone')
 
@@ -55,10 +55,11 @@ JSON.parse(response)
 ```
 
 ## Usage
-
 ### [Browse API]
 
-The Browse API allows your buyers to search eBay items by keyword and category. It also allows them to view and add items to their eBay shopping cart.
+The Browse API allows your buyers to search eBay items by keyword and category. It also allows them to view and add items to their eBay shopping cart. The Browse API defaults to the eBay US marketplace but may be set during initialisation. The list of available marketplaces is [here](https://developer.ebay.com/api-docs/static/rest-request-components.html#marketpl).
+
+**Note** The marketplace value needs to use an underscore between EBAY and the country code.  The Other APIs use a hyphen.
 
 ```ruby
 require 'ebay/browse'
@@ -66,7 +67,7 @@ require 'ebay/oauth/client_credentials_grant'
 
 access_token = Oauth::ClientCredentialsGrant.new.mint_access_token
 request = Ebay.browse(campaign_id: '123', country: 'US', zip: '19406',
-                      access_token: access_token)
+                      access_token: access_token, market_id: 'EBAY_US')
 response = request.search(q: 'iphone')
 ```
 
@@ -102,6 +103,11 @@ require 'ebay/shopping'
 request = Ebay::Shopping.new
 response = request.find_products('QueryKeywords' => 'tolkien')
 ```
+
+### Market Place
+eBay has country bsaed marketplaces ( listed [here](https://developer.ebay.com/api-docs/static/rest-request-components.html#marketpl) ).  By default, the eBay gem queries the US Marketplace.  To change the marketplace, set the marketplace on the request object.
+
+**Note** For the Browse API, the marketplace value needs to use an underscore between EBAY and the country code (EBAY_AU).  The other APIs require a hyphen between EBAY and the country code ( EBAY-AU )
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ JSON.parse(response)
 
 The Browse API allows your buyers to search eBay items by keyword and category. It also allows them to view and add items to their eBay shopping cart. The Browse API defaults to the eBay US marketplace but may be set during initialisation. The list of available marketplaces is [here](https://developer.ebay.com/api-docs/static/rest-request-components.html#marketpl).
 
-**Note** The marketplace value needs to use an underscore between EBAY and the country code.  The Other APIs use a hyphen.
+**Note** The marketplace value needs to use an underscore between EBAY and the country code.  The Finding and Merchandising APIs use a hyphen.
 
 ```ruby
 require 'ebay/browse'
@@ -107,7 +107,7 @@ response = request.find_products('QueryKeywords' => 'tolkien')
 ### Market Place
 eBay has country bsaed marketplaces ( listed [here](https://developer.ebay.com/api-docs/static/rest-request-components.html#marketpl) ).  By default, the eBay gem queries the US Marketplace.  To change the marketplace, set the marketplace on the request object.
 
-**Note** For the Browse API, the marketplace value needs to use an underscore between EBAY and the country code (EBAY_AU).  The other APIs require a hyphen between EBAY and the country code ( EBAY-AU )
+**Note** For the Browse API, the marketplace value needs to use an underscore between EBAY and the country code (EBAY_AU).  The Finding and Merchandising APIs require a hyphen between EBAY and the country code ( EBAY-AU )
 
 ## Development
 

--- a/lib/ebay/finding.rb
+++ b/lib/ebay/finding.rb
@@ -143,7 +143,7 @@ module Ebay
                  'SECURITY-APPNAME' => security_appname,
                  'SERVICE-VERSION' => service_version }.update(payload).compact
 
-      http.get(endpoint, params: params)
+      http.headers(headers).get(endpoint, params: params)
     end
   end
 end

--- a/lib/ebay/merchandising.rb
+++ b/lib/ebay/merchandising.rb
@@ -90,7 +90,7 @@ module Ebay
                  'RESPONSE-DATA-FORMAT' => response_data_format,
                  'SERVICE-VERSION' => service_version }.compact
 
-      http.post(endpoint, params: params, body: JSON.dump(payload))
+      http.headers(headers).post(endpoint, params: params, body: JSON.dump(payload))
     end
   end
 end

--- a/lib/ebay/requestable.rb
+++ b/lib/ebay/requestable.rb
@@ -18,6 +18,18 @@ module Ebay
     # @return [HTTP::Client]
     attr_writer :http
 
+    # @!attribute [r] headers
+    # @return [Hash]
+    attr_accessor :headers
+
+    # Sets the eBay Market
+    #
+    # @param [String]
+    def market_id=(market_id)
+      @headers ||= {}
+      @headers['X-EBAY-SOA-GLOBAL-ID'] = market_id
+    end
+
     # @!attribute [r] http
     # @return [HTTP::Client]
     def http
@@ -59,7 +71,7 @@ module Ebay
     #   @param [Array] proxy
     #   @raise [HTTP::Request::Error] if HTTP proxy is invalid
     #   @return [self]
-    %i[timeout via through headers use].each do |method_name|
+    %i[timeout via through use].each do |method_name|
       define_method(method_name) do |*args, &block|
         self.http = http.send(method_name, *args, &block)
         self

--- a/lib/ebay/shopping.rb
+++ b/lib/ebay/shopping.rb
@@ -163,7 +163,7 @@ module Ebay
                  'trackingid' => tracking_id,
                  'trackingpartnercode' => tracking_partner_code }.compact
 
-      http.post(endpoint, params: params, body: JSON.dump(payload))
+      http.headers(headers).post(endpoint, params: params, body: JSON.dump(payload))
     end
   end
 end


### PR DESCRIPTION
I haven't used these APIs previously.  They correctly return the marketplace domains now and the tests pass.

Note that the header doesn't seem to work with the Shopping API.  I've never used that API either, but the [documentation](https://developer.ebay.com/Devzone/shopping/docs/CallRef/FindProducts.html#Request.DomainName) talks about adding the domain you're querying directly as a parameter. 

For Finding and Merchandising you can test that the market_id actually effects the results

```ruby
request = Ebay.finding(response_data_format: 'JSON')
request.market_id='EBAY-GB'
response = request.find_items_by_keywords('iphone')
doc = JSON.parse(response.body.to_s)
doc.dig('findItemsByKeywordsResponse',0, 'itemSearchURL')
```

Confirm that the returned URL is ebay.co.uk

```ruby
request = Ebay::Merchandising.new(response_data_format: 'JSON')
request.market_id='EBAY-AU'
response = request.get_most_watched_items
doc = JSON.parse(response.body.to_s)
doc.dig('getMostWatchedItemsResponse', 'itemRecommendations', 'item', 0, 'viewItemURL')
```

Confirm that the returned URL is ebay.com.au
